### PR TITLE
Fix delete button in echo-http-counter demo

### DIFF
--- a/demo/echo-http-counter/templates/delete.html
+++ b/demo/echo-http-counter/templates/delete.html
@@ -1,4 +1,4 @@
-<button @click="delete:/count" before="return confirm('Are you sure?')">
+<button @click="delete:/count" before="confirm('Are you sure?')">
   Delete
   <span :html="count.val"></span>
 </button>


### PR DESCRIPTION
Interacting with the delete button in the demo causes a `SyntaxError: Unexpected token 'return'` error (see screenshot). This is because the `before` attribute of the delete button had a value of `return confirm('Are you sure?')`, resulting in a newly created function containing `return return confirm('Are you sure?')`.

This commit removes the redundant "return" of the delete button's `before` attribute, which resolves the previously mentioned error.

![2024-01-03_18-33](https://github.com/awesome-club/not-a-framework/assets/5613362/97843bb3-b802-4e05-91cb-fa7f0fab5a81)
